### PR TITLE
Visual C++ fixes

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -31,17 +31,17 @@ match = ^share/lib
 match = ^t/ffi/_build
 
 [Prereqs]
-FFI::Build = 0.84
-FFI::Platypus = 0.84
+FFI::Build = 1.05
+FFI::Platypus = 1.05
 
 [Prereqs / ConfigureRequires]
 -phase = configure
 ExtUtils::MakeMaker = 7.30
-FFI::Build::MM = 0.84
+FFI::Build::MM = 1.05
 
 [Prereqs / BuildRequires]
 -phase = build
-FFI::Build = 0.84
+FFI::Build = 1.05
 
 [Author::Plicease::Upload]
 cpan = 1

--- a/ffi/simple.c
+++ b/ffi/simple.c
@@ -3,6 +3,11 @@
 #include <stdarg.h>
 
 #define T2T_SIMPLE_API_ONLY
+#ifdef _MSC_VER
+#define T2T_SIMPLE_EXPORT __declspec(dllexport)
+#else
+#define T2T_SIMPLE_EXPORT
+#endif
 #include <t2t/simple.h>
 
 struct {
@@ -110,7 +115,6 @@ t2t_simple_diagf(const char *language, const char *filename, int linenumber, con
   else
     do_abort();
 }
-
 
 int
 t2t_simple_pass(const char *language, const char *filename, int linenumber, const char *function, const char *name)

--- a/share/include/t2t/simple.h
+++ b/share/include/t2t/simple.h
@@ -5,14 +5,22 @@
 extern "C" {
 #endif
 
+#ifndef T2T_SIMPLE_EXPORT
+#ifdef _MSC_VER
+#define T2T_SIMPLE_EXPORT __declspec(dllimport)
+#else
+#define T2T_SIMPLE_EXPORT
+#endif
+#endif
+
 typedef void (*t2t_simple_message_cb)(const char *, const char *, const char *, int, const char *);
 
-void t2t_simple_note(const char *, const char *, int, const char *, const char *);
-void t2t_simple_notef(const char *, const char *, int, const char *, const char *, ...);
-void t2t_simple_diag(const char *, const char *, int, const char *, const char *);
-void t2t_simple_diagf(const char *, const char *, int, const char *, const char *, ...);
-int t2t_simple_pass(const char *, const char *, int, const char *, const char *);
-int t2t_simple_fail(const char *, const char *, int, const char *, const char *);
+T2T_SIMPLE_EXPORT void t2t_simple_note(const char *, const char *, int, const char *, const char *);
+T2T_SIMPLE_EXPORT void t2t_simple_notef(const char *, const char *, int, const char *, const char *, ...);
+T2T_SIMPLE_EXPORT void t2t_simple_diag(const char *, const char *, int, const char *, const char *);
+T2T_SIMPLE_EXPORT void t2t_simple_diagf(const char *, const char *, int, const char *, const char *, ...);
+T2T_SIMPLE_EXPORT int t2t_simple_pass(const char *, const char *, int, const char *, const char *);
+T2T_SIMPLE_EXPORT int t2t_simple_fail(const char *, const char *, int, const char *, const char *);
 
 #ifndef T2T_SIMPLE_API_ONLY
 #define note(message) t2t_simple_note("c", __FILE__, __LINE__, __func__, message)
@@ -24,8 +32,8 @@ int t2t_simple_fail(const char *, const char *, int, const char *, const char *)
 #define ok(expression, message) expression ? t2t_simple_pass("c", __FILE__, __LINE__, __func__, message) : t2t_simple_fail("c", __FILE__, __LINE__, __func__, message)
 #endif
 
-void t2t_simple_init(t2t_simple_message_cb, t2t_simple_message_cb, t2t_simple_message_cb, t2t_simple_message_cb);
-void t2t_simple_deinit();
+T2T_SIMPLE_EXPORT void t2t_simple_init(t2t_simple_message_cb, t2t_simple_message_cb, t2t_simple_message_cb, t2t_simple_message_cb);
+T2T_SIMPLE_EXPORT void t2t_simple_deinit();
 
 #ifdef __cplusplus
 }

--- a/t/00_diag.t
+++ b/t/00_diag.t
@@ -1,7 +1,7 @@
 use Test2::V0 -no_srand => 1;
 use Config;
 
-eval q{ require Test::More };
+eval { require 'Test/More.pm' };
 
 # This .t file is generated.
 # make changes instead to dist.ini
@@ -37,7 +37,7 @@ pass 'okay';
 
 my $max = 1;
 $max = $_ > $max ? $_ : $max for map { length $_ } @modules;
-our $format = "%-${max}s %s"; 
+our $format = "%-${max}s %s";
 
 spacer;
 
@@ -46,13 +46,13 @@ my @keys = sort grep /(MOJO|PERL|\A(LC|HARNESS)_|\A(SHELL|LANG)\Z)/i, keys %ENV;
 if(@keys > 0)
 {
   diag "$_=$ENV{$_}" for @keys;
-  
+
   if($ENV{PERL5LIB})
   {
     spacer;
     diag "PERL5LIB path";
     diag $_ for split $Config{path_sep}, $ENV{PERL5LIB};
-    
+
   }
   elsif($ENV{PERLLIB})
   {
@@ -60,7 +60,7 @@ if(@keys > 0)
     diag "PERLLIB path";
     diag $_ for split $Config{path_sep}, $ENV{PERLLIB};
   }
-  
+
   spacer;
 }
 
@@ -68,9 +68,11 @@ diag sprintf $format, 'perl ', $];
 
 foreach my $module (sort @modules)
 {
-  if(eval qq{ require $module; 1 })
+  my $pm = "$module.pm";
+  $pm =~ s{::}{/}g;
+  if(eval { require $pm; 1 })
   {
-    my $ver = eval qq{ \$$module\::VERSION };
+    my $ver = eval { $module->VERSION };
     $ver = 'undef' unless defined $ver;
     diag sprintf $format, $module, $ver;
   }

--- a/t/ffi/test.c
+++ b/t/ffi/test.c
@@ -1,11 +1,14 @@
+#include <ffi_platypus_bundle.h>
 #include <t2t/simple.h>
 
+EXPORT
 int
 myanswer()
 {
   return 42;
 }
 
+EXPORT
 void
 test_simple_diagnostics()
 {
@@ -14,6 +17,7 @@ test_simple_diagnostics()
   diag("this is IMPORTANT, make sure we see it");
 }
 
+EXPORT
 void
 test_format_diagnostics()
 {
@@ -21,6 +25,7 @@ test_format_diagnostics()
   diagf("diag number = %d", 47);
 }
 
+EXPORT
 void test_simple_passfail()
 {
   pass("this is a passing test");


### PR DESCRIPTION
This fixes the build but not the test.  The test fail requires some extra support possibly in platypus itself.  The problem is that the test is depending on code in the ffi library.  I Linux we can link at runtime to get the missing functions, but on windows I think we may need to link against the actual dll at link time.